### PR TITLE
add google search console

### DIFF
--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -19,6 +19,12 @@ export const metadata: Metadata = {
 export default function RootLayout({ children }: PropsWithChildren) {
   return (
     <html lang="en">
+      <head>
+        <meta
+          name="google-site-verification"
+          content="Rnm3DL87HNmPncIFwBLXPhy-WGFDXIyplSL4fRtnFsA"
+        />
+      </head>
       <body className={kongtext.className}>
         <WalletProvider>{children}</WalletProvider>
         <GeoTargetly />


### PR DESCRIPTION
- add Aptogotchi Intermediate to Google search results, using [Google Search Console](https://search.google.com/search-console/welcome?utm_source=about-page)
- verify ownership of [aptogotchi-intermediate.aptoslabs.com](https://aptogotchi-intermediate.aptoslabs.com/)